### PR TITLE
Command-line options for overriding configuration

### DIFF
--- a/config.js
+++ b/config.js
@@ -4,9 +4,36 @@
 // @module config.js
 // ---------------------------------------------------------------------------------------------------------------------
 
+var _ = require('lodash');
+
+// ---------------------------------------------------------------------------------------------------------------------
+
 module.exports = {
-    DEBUG: true,
+    DEBUG: parseBool(process.env.DEBUG, true),
     port: 8008
 }; // end exports
+
+// ---------------------------------------------------------------------------------------------------------------------
+
+var argv = require('minimist')(process.argv.slice(2), {boolean: true});
+_.merge(module.exports, _.omit(argv, '_'));
+
+// ---------------------------------------------------------------------------------------------------------------------
+
+function parseBool(boolString, defaultValue)
+{
+    switch(boolString || ''.toLowerCase())
+    {
+        case '0':
+        case 'false':
+        case 'off':
+        case 'no':
+            return false;
+        case '':
+            return defaultValue;
+        default:
+            return true;
+    } // end switch
+} // end parseBool
 
 // ---------------------------------------------------------------------------------------------------------------------

--- a/config.js
+++ b/config.js
@@ -28,9 +28,10 @@ _.merge(module.exports, _.omit(argv, '_'));
 
 // ---------------------------------------------------------------------------------------------------------------------
 
+// Parse a string as a boolean. (used to support boolean flags in environment variables)
 function parseBool(boolString, defaultValue)
 {
-    switch(boolString || ''.toLowerCase())
+    switch((boolString || '').toLowerCase())
     {
         case '0':
         case 'false':

--- a/config.js
+++ b/config.js
@@ -10,6 +10,8 @@ var _ = require('lodash');
 
 module.exports = {
     DEBUG: parseBool(process.env.DEBUG, true),
+    logLevel: process.env.LOG_LEVEL || 'DEBUG',
+
     port: 8008
 }; // end exports
 

--- a/config.js
+++ b/config.js
@@ -4,6 +4,8 @@
 // @module config.js
 // ---------------------------------------------------------------------------------------------------------------------
 
+var path = require('path');
+
 var _ = require('lodash');
 
 // ---------------------------------------------------------------------------------------------------------------------
@@ -22,8 +24,39 @@ module.exports = {
 }; // end exports
 
 // ---------------------------------------------------------------------------------------------------------------------
+// Parse command-line options.
 
-var argv = require('minimist')(process.argv.slice(2), {boolean: true});
+var argv = require('minimist')(process.argv.slice(2), { alias: { help: 'h' }, boolean: true });
+
+if(argv.help)
+{
+    var e = console.error.bind(console);
+    e('');
+    e('  Usage: %s [options]', path.basename(process.argv[1]));
+    e('');
+    e('  Initialize the database with data');
+    e('');
+    e('  Options:');
+    e('');
+    e('    -h, --help                 output usage information');
+    e('');
+    e('    --<config.option>=<value>  set configuration option to <value>');
+    e('    --<config.option>          set configuration option to `true`');
+    e('');
+
+    // If another module has registered extra lines for the help message, display them.
+    if(GLOBAL.extraHelp)
+    {
+        GLOBAL.extraHelp.forEach(function(extraHelpLine)
+        {
+            e(extraHelpLine);
+        });
+        e('');
+    } // end if
+
+    process.exit(1);
+} // end if
+
 _.merge(module.exports, _.omit(argv, '_'));
 
 // ---------------------------------------------------------------------------------------------------------------------

--- a/config.js
+++ b/config.js
@@ -12,7 +12,13 @@ module.exports = {
     DEBUG: parseBool(process.env.DEBUG, true),
     logLevel: process.env.LOG_LEVEL || 'DEBUG',
 
-    port: 8008
+    port: 8008,
+
+    rethinkdb: {
+        host: 'localhost',
+        port: 28015,
+        db: 'rfi_mmorpg'
+    }
 }; // end exports
 
 // ---------------------------------------------------------------------------------------------------------------------

--- a/config.js
+++ b/config.js
@@ -34,7 +34,7 @@ if(argv.help)
     e('');
     e('  Usage: %s [options]', path.basename(process.argv[1]));
     e('');
-    e('  Initialize the database with data');
+    e('  ' + GLOBAL.programDesc);
     e('');
     e('  Options:');
     e('');

--- a/lib/models.js
+++ b/lib/models.js
@@ -4,7 +4,8 @@
 // @module models
 //----------------------------------------------------------------------------------------------------------------------
 
-var thinky = require('thinky')({ db: 'rfi_mmorpg' });
+var config = require('../config');
+var thinky = require('thinky')(config.rethinkdb);
 var db = { r: thinky.r, errors: thinky.Errors };
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   "license": "MIT",
   "dependencies": {
     "bluebird": "^2.3.2",
-    "commander": "^2.6.0",
     "lodash": "^2.4.1",
     "minimist": "^1.1.1",
     "node-uuid": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "bluebird": "^2.3.2",
     "commander": "^2.6.0",
     "lodash": "^2.4.1",
+    "minimist": "^1.1.1",
     "node-uuid": "^1.4.1",
     "omega-logger": "^0.5.6",
     "rfi-physics": "git+https://github.com/SkewedAspect/rfi-physics.git",

--- a/scripts/initdb.js
+++ b/scripts/initdb.js
@@ -9,6 +9,7 @@
 var _ = require('lodash');
 var Promise = require('bluebird');
 
+GLOBAL.programDesc = 'Initialize the database with data';
 GLOBAL.extraHelp = ['    --production               production mode (skips populating development accounts)'];
 var config = require('../config');
 

--- a/scripts/initdb.js
+++ b/scripts/initdb.js
@@ -7,8 +7,10 @@
 // ---------------------------------------------------------------------------------------------------------------------
 
 var _ = require('lodash');
-var program = require('commander');
 var Promise = require('bluebird');
+
+GLOBAL.extraHelp = ['    --production               production mode (skips populating development accounts)'];
+var config = require('../config');
 
 var package = require('../package');
 var models = require('../lib/models');
@@ -18,14 +20,6 @@ var accounts = require('../data/accounts');
 var characters = require('../data/characters');
 var ship_instances = require('../data/ship_instances');
 var ship_templates = require('../data/ship_templates');
-
-// ---------------------------------------------------------------------------------------------------------------------
-
-program
-    .version(package.version)
-    .description('initializes the database with data')
-    .option('-p, --production', 'Production mode. (Skips populating development accounts.)')
-    .parse(process.argv);
 
 // ---------------------------------------------------------------------------------------------------------------------
 
@@ -49,7 +43,7 @@ function loadClean(Model, initialData)
 var loadPromise = loadClean(models.ShipTemplate, ship_templates);
 
 // Check to see if we're in production mode
-if(!program.production)
+if(!config.production)
 {
     loadPromise = loadPromise
         .then(function()

--- a/server.js
+++ b/server.js
@@ -19,8 +19,8 @@ var logger = logging.loggerFor(module);
 
 if(config.DEBUG)
 {
-    logging.root.handlers[0].level = process.env.LOG_LEVEL || 'DEBUG';
-    logger.debug('Server starting in DEBUG mode.');
+    logging.root.handlers[0].level = config.logLevel;
+    logger.info('Server starting in DEBUG mode.');
 } // end if
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/server.js
+++ b/server.js
@@ -7,6 +7,7 @@
 var _ = require('lodash');
 var socketio = require('socket.io');
 
+GLOBAL.programDesc = 'Start the RFI: Precursors server';
 var config = require('./config');
 var package = require('./package');
 var RFIClient = require('./lib/client');


### PR DESCRIPTION
This adds option parsing, such that configuration options can be overridden on the command-line.

For example, the command:
```bash
node server.js --port=80 --rethinkdb.host=rethinkdb
```
is equivalent to running `server.js` after editing `config.js` to include:
```javascript
{
    port: 80,
    rethinkdb: {
        host: 'rethinkdb',
        //...
   },
    //...
}
```

This change also:
- removes our dependency on the `commander` package, replacing it with `minimist`
- makes `DEBUG` mode configurable through the `DEBUG` environment variable (instead of just the `DEBUG` config option)
- makes the `omega-logger` log level configurable through the `logLevel` config option (instead of just the `LOG_LEVEL` environment variable)