### PR TITLE
Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.DS_Store
+
+# IntelliJ artifacts
+.idea
+
+# Node artifacts
+node_modules
+
+# Git artifacts
+.git*
+
+# Stuff that doesn't need to be copied to the docker daemon up front
+data

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:0.12-slim
+EXPOSE 8008
+
+ADD . /code/
+RUN buildDeps='ca-certificates git' \
+	&& set -x \
+	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
+	&& cd /code \
+	&& npm install \
+	&& apt-get purge -y --auto-remove $buildDeps \
+	&& npm cache clear
+
+VOLUME [ "/code/node_modules" ]
+
+WORKDIR /code
+CMD [ "npm", "start" ]

--- a/Readme.md
+++ b/Readme.md
@@ -5,32 +5,98 @@
 [![Issues in Progress](https://badge.waffle.io/SkewedAspect/rfi-webgl-client.png?label=in progress&title=In Progress Issues)](https://waffle.io/SkewedAspect/rfi-webgl-client)
 [![Issues Needing Review](https://badge.waffle.io/SkewedAspect/rfi-webgl-client.png?label=needs review&title=Issues Needing Review)](https://waffle.io/SkewedAspect/rfi-webgl-client)
 
-This is a nodejs implementation of the RFI: Precursors server.
+This is a Node.js implementation of the RFI: Precursors server.
 
-## Setup
 
-First, you will need to install [`rethinkdb`](http://rethinkdb.com/docs/install/). Follow the instructions for your 
-platform. Next, install the npm modules:
+## Running the Server
 
+Before you get started, you'll need to make sure that you have the server's dependencies installed:
 ```bash
-$ npm install
+npm install
 ```
 
-After that completes, create the test user in the database:
+Next, you have a few options for how to run the server...
 
+
+### Running in a Docker Container
+
+Before starting, you'll need [docker](https://docs.docker.com/) and
+[docker-compose](https://docs.docker.com/compose/install/) installed.
+
+The first time you set up your Docker containers, you'll need to initialize the database. To do this, bring up the
+`rethinkdb` service, run `scripts/initdb.sh`, and stop the `rethinkdb` service:
 ```bash
-$ node ./scripts/initdb.js
+docker-compose up -d rethinkdb
+
+scripts/initdb.js --rethinkdb.host=$(docker inspect -f '{{.NetworkSettings.IPAddress}}' rfiserver_rethinkdb_1)
+# If using `fish`: scripts/initdb.js --rethinkdb.host=(docker inspect -f '{{.NetworkSettings.IPAddress}}' rfiserver_rethinkdb_1)
+
+docker-compose stop rethinkdb
 ```
 
-_Note: If you don't want the development accounts, pass the `-p` option._
+Finally, bring up all defined services:
+```fish
+docker-compose up
+```
+
+Now, the server should be running and listening on port 8008; you can then bring up and connect any client.
+
+----
+
+### Running Directly
+
+#### Set up RethinkDB
+
+First, you will need to either install RethinkDB on your system, or use the `rethinkdb` Docker image.
+
+To install RethinkDB on your system, follow [the instructions for your platform](http://rethinkdb.com/docs/install/).
+
+To use the Docker image, first [install docker](https://docs.docker.com/). Then, run the following command to create
+and start a new RethinkDB container:
+```bash
+docker run --name rfi-rethinkdb -v $PWD:/data -p 28015:28015 -d rethinkdb
+# If using `fish`: docker run --name rfi-rethinkdb -v (pwd):/data -p 28015:28015 -d rethinkdb
+```
+
+From now on, you can use `docker ps` to check on your container, `docker stop rfi-rethinkdb` to stop the running
+container, and `docker start rfi-rethinkdb` to start it again. To connect to your RethinkDB instance's administration
+UI, use the following command:
+```bash
+$BROWSER http://$(docker inspect -f '{{.NetworkSettings.IPAddress}}' rfi-rethinkdb):8080
+# If using `fish`: eval $BROWSER http://(docker inspect -f '{{.NetworkSettings.IPAddress}}' rfi-rethinkdb):8080
+```
+
+Once you have an accesible RethinkDB instance, create the tables in the database, and populate them with test data:
+```bash
+node ./scripts/initdb.js
+```
+
+_Note: If you don't want the development accounts, pass the `--production` option._
+
+#### Run the Server
+
+Use `npm` to start the server:
+```bash
+npm start
+```
+
+Or, alternatively, start the server directly:
+```bash
+node server.js
+```
+
+Starting the server directly allows you to override configuration options on the command line; see
+`node server.js --help` for more information.
+
+----
+
 
 ## Unit Tests
 
 To run the unit tests, simple run:
 
 ```bash
-$ npm test
+npm test
 ```
 
 All tests should pass.
-

--- a/config.js
+++ b/config.js
@@ -4,9 +4,36 @@
 // @module config.js
 // ---------------------------------------------------------------------------------------------------------------------
 
+var _ = require('lodash');
+
+// ---------------------------------------------------------------------------------------------------------------------
+
 module.exports = {
-    DEBUG: true,
+    DEBUG: parseBool(process.env.DEBUG, true),
     port: 8008
 }; // end exports
+
+// ---------------------------------------------------------------------------------------------------------------------
+
+var argv = require('minimist')(process.argv.slice(2), {boolean: true});
+_.merge(module.exports, _.omit(argv, '_'));
+
+// ---------------------------------------------------------------------------------------------------------------------
+
+function parseBool(boolString, defaultValue)
+{
+    switch(boolString || ''.toLowerCase())
+    {
+        case '0':
+        case 'false':
+        case 'off':
+        case 'no':
+            return false;
+        case '':
+            return defaultValue;
+        default:
+            return true;
+    } // end switch
+} // end parseBool
 
 // ---------------------------------------------------------------------------------------------------------------------

--- a/config.js
+++ b/config.js
@@ -28,9 +28,10 @@ _.merge(module.exports, _.omit(argv, '_'));
 
 // ---------------------------------------------------------------------------------------------------------------------
 
+// Parse a string as a boolean. (used to support boolean flags in environment variables)
 function parseBool(boolString, defaultValue)
 {
-    switch(boolString || ''.toLowerCase())
+    switch((boolString || '').toLowerCase())
     {
         case '0':
         case 'false':

--- a/config.js
+++ b/config.js
@@ -10,6 +10,8 @@ var _ = require('lodash');
 
 module.exports = {
     DEBUG: parseBool(process.env.DEBUG, true),
+    logLevel: process.env.LOG_LEVEL || 'DEBUG',
+
     port: 8008
 }; // end exports
 

--- a/config.js
+++ b/config.js
@@ -4,6 +4,8 @@
 // @module config.js
 // ---------------------------------------------------------------------------------------------------------------------
 
+var path = require('path');
+
 var _ = require('lodash');
 
 // ---------------------------------------------------------------------------------------------------------------------
@@ -22,8 +24,39 @@ module.exports = {
 }; // end exports
 
 // ---------------------------------------------------------------------------------------------------------------------
+// Parse command-line options.
 
-var argv = require('minimist')(process.argv.slice(2), {boolean: true});
+var argv = require('minimist')(process.argv.slice(2), { alias: { help: 'h' }, boolean: true });
+
+if(argv.help)
+{
+    var e = console.error.bind(console);
+    e('');
+    e('  Usage: %s [options]', path.basename(process.argv[1]));
+    e('');
+    e('  Initialize the database with data');
+    e('');
+    e('  Options:');
+    e('');
+    e('    -h, --help                 output usage information');
+    e('');
+    e('    --<config.option>=<value>  set configuration option to <value>');
+    e('    --<config.option>          set configuration option to `true`');
+    e('');
+
+    // If another module has registered extra lines for the help message, display them.
+    if(GLOBAL.extraHelp)
+    {
+        GLOBAL.extraHelp.forEach(function(extraHelpLine)
+        {
+            e(extraHelpLine);
+        });
+        e('');
+    } // end if
+
+    process.exit(1);
+} // end if
+
 _.merge(module.exports, _.omit(argv, '_'));
 
 // ---------------------------------------------------------------------------------------------------------------------

--- a/config.js
+++ b/config.js
@@ -12,7 +12,13 @@ module.exports = {
     DEBUG: parseBool(process.env.DEBUG, true),
     logLevel: process.env.LOG_LEVEL || 'DEBUG',
 
-    port: 8008
+    port: 8008,
+
+    rethinkdb: {
+        host: 'localhost',
+        port: 28015,
+        db: 'rfi_mmorpg'
+    }
 }; // end exports
 
 // ---------------------------------------------------------------------------------------------------------------------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+rethinkdb:
+    image: rethinkdb:2.0
+    volumes:
+        - .:/data
+
+server:
+    build: .
+    command: node server.js --rethinkdb.host=rethinkdb
+    ports:
+        - "8008:8008"
+    volumes:
+        - .:/code
+    links:
+        - rethinkdb

--- a/docker-rethinkdb-admin.sh
+++ b/docker-rethinkdb-admin.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+$BROWSER "http://$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' rfiserver_rethinkdb_1):8080"

--- a/lib/models.js
+++ b/lib/models.js
@@ -4,7 +4,8 @@
 // @module models
 //----------------------------------------------------------------------------------------------------------------------
 
-var thinky = require('thinky')({ db: 'rfi_mmorpg' });
+var config = require('../config');
+var thinky = require('thinky')(config.rethinkdb);
 var db = { r: thinky.r, errors: thinky.Errors };
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   "license": "MIT",
   "dependencies": {
     "bluebird": "^2.3.2",
-    "commander": "^2.6.0",
     "lodash": "^2.4.1",
     "minimist": "^1.1.1",
     "node-uuid": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "bluebird": "^2.3.2",
     "commander": "^2.6.0",
     "lodash": "^2.4.1",
+    "minimist": "^1.1.1",
     "node-uuid": "^1.4.1",
     "omega-logger": "^0.5.6",
     "rfi-physics": "git+https://github.com/SkewedAspect/rfi-physics.git",

--- a/scripts/initdb.js
+++ b/scripts/initdb.js
@@ -7,8 +7,10 @@
 // ---------------------------------------------------------------------------------------------------------------------
 
 var _ = require('lodash');
-var program = require('commander');
 var Promise = require('bluebird');
+
+GLOBAL.extraHelp = ['    --production               production mode (skips populating development accounts)'];
+var config = require('../config');
 
 var package = require('../package');
 var models = require('../lib/models');
@@ -18,14 +20,6 @@ var accounts = require('../data/accounts');
 var characters = require('../data/characters');
 var ship_instances = require('../data/ship_instances');
 var ship_templates = require('../data/ship_templates');
-
-// ---------------------------------------------------------------------------------------------------------------------
-
-program
-    .version(package.version)
-    .description('initializes the database with data')
-    .option('-p, --production', 'Production mode. (Skips populating development accounts.)')
-    .parse(process.argv);
 
 // ---------------------------------------------------------------------------------------------------------------------
 
@@ -49,7 +43,7 @@ function loadClean(Model, initialData)
 var loadPromise = loadClean(models.ShipTemplate, ship_templates);
 
 // Check to see if we're in production mode
-if(!program.production)
+if(!config.production)
 {
     loadPromise = loadPromise
         .then(function()

--- a/server.js
+++ b/server.js
@@ -19,8 +19,8 @@ var logger = logging.loggerFor(module);
 
 if(config.DEBUG)
 {
-    logging.root.handlers[0].level = process.env.LOG_LEVEL || 'DEBUG';
-    logger.debug('Server starting in DEBUG mode.');
+    logging.root.handlers[0].level = config.logLevel;
+    logger.info('Server starting in DEBUG mode.');
 } // end if
 
 //----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This adds support for running the server in a Docker container, and also provides a RethinkDB container so developers don't need to install RethinkDB. See [Readme.md](https://github.com/SkewedAspect/rfi-server/blob/40de1628a6544e4751a52f3d9121c19774750d1f/Readme.md) for details.

Requires #19.